### PR TITLE
use psycopg2-binary package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 pip # get rid of annoying pip messages
 
-psycopg2==2.6.1
+psycopg2-binary==2.8.4
 python-dateutil==2.5.3
 
 pyexcel==0.2.1


### PR DESCRIPTION
- using the `binary` package is avoids an installation error for virtualenv
- lifting the version to 2.8.4 was a requirement after the OS upgrade